### PR TITLE
Updating on-demand price check from new JSONs

### DIFF
--- a/ec2instancespricing.py
+++ b/ec2instancespricing.py
@@ -115,12 +115,12 @@ EC2_REGIONS_API_TO_JSON_NAME = {
     "us-gov-west-1" : "us-gov-west-1"
 }
 
-INSTANCES_ON_DEMAND_LINUX_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/linux-od.js"
-INSTANCES_ON_DEMAND_RHEL_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/rhel-od.js"
-INSTANCES_ON_DEMAND_SLES_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/sles-od.js"
-INSTANCES_ON_DEMAND_WINDOWS_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/mswin-od.js"
-INSTANCES_ON_DEMAND_WINSQL_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/mswinSQL-od.js"
-INSTANCES_ON_DEMAND_WINSQLWEB_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/mswinSQLWeb-od.js"
+INSTANCES_ON_DEMAND_LINUX_URL = "http://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js"
+INSTANCES_ON_DEMAND_RHEL_URL = "http://a0.awsstatic.com/pricing/1/ec2/rhel-od.min.js"
+INSTANCES_ON_DEMAND_SLES_URL = "http://a0.awsstatic.com/pricing/1/ec2/sles-od.min.js"
+INSTANCES_ON_DEMAND_WINDOWS_URL = "http://a0.awsstatic.com/pricing/1/ec2/mswin-od.min.js"
+INSTANCES_ON_DEMAND_WINSQL_URL = "http://a0.awsstatic.com/pricing/1/ec2/mswinSQL-od.min.js"
+INSTANCES_ON_DEMAND_WINSQLWEB_URL = "http://a0.awsstatic.com/pricing/1/ec2/mswinSQLWeb-od.min.js"
 INSTANCES_RESERVED_LIGHT_UTILIZATION_LINUX_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/linux-ri-light.js"
 INSTANCES_RESERVED_LIGHT_UTILIZATION_RHEL_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/rhel-ri-light.js"
 INSTANCES_RESERVED_LIGHT_UTILIZATION_SLES_URL = "http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/sles-ri-light.js"
@@ -264,10 +264,12 @@ def _load_data(url, use_cache=False, cache_class=SimpleResultsCache):
     f = urllib2.urlopen(url)
     request = f.read()
 
+    # strip initial comment (with newline)
+    modified_request = re.sub(re.compile(r'/\*.*\*/\n', re.DOTALL), '', request)
     # strip from front of request
-    modified_request = re.sub(r'^callback\(', '', request)
+    modified_request = re.sub(r'^callback\(', '', modified_request)
     # strip from end of request
-    modified_request = re.sub(r'\)$', '', modified_request)
+    modified_request = re.sub(r'\);$', '', modified_request)
 
     json = demjson.decode(modified_request)
 


### PR DESCRIPTION
The official EC2 Pricing page is fetching on-demand prices from different URLs. Fixing this.