### PR TITLE
Callback regex changed as body of reserved instance repsonses end in ")" not ");". 

### DIFF
--- a/ec2instancespricing.py
+++ b/ec2instancespricing.py
@@ -269,7 +269,7 @@ def _load_data(url, use_cache=False, cache_class=SimpleResultsCache):
     # strip from front of request
     modified_request = re.sub(r'^callback\(', '', modified_request)
     # strip from end of request
-    modified_request = re.sub(r'\);$', '', modified_request)
+    modified_request = re.sub(r'\);*$', '', modified_request)
 
     json = demjson.decode(modified_request)
 


### PR DESCRIPTION
 Regex changed to cope with both forms as on demand responses still end in ");". 

Examples:
reserved:     http://aws-assets-pricing-prod.s3.amazonaws.com/pricing/ec2/linux-ri-light.js
on demand: http://a0.awsstatic.com/pricing/1/ec2/rhel-od.min.js

