### PR TITLE
Adding statsd output format

### DIFF
--- a/ec2instancespricing/ec2instancespricing.py
+++ b/ec2instancespricing/ec2instancespricing.py
@@ -759,7 +759,7 @@ def _get_args(args):
     parser.add_argument("--filter-type-pattern", "-fp", help="Filter results to a specific instance type pattern", choices=EC2_INSTANCE_TYPES_PATTERN, default=None)
     parser.add_argument("--filter-os-type", "-fo", help="Filter results to a specific os type", choices=EC2_OS_TYPES, default="linux")
     parser.add_argument("--format", "-f", choices=OUTPUT_FORMATS, help="Output format", default="table")
-    parser.add_argument("--statsd-prefix", "-sp", help="Pass the prefix of the metric you want to have", default="statsd.ec2instancespricing")
+    parser.add_argument("--statsd-prefix", "-sp", help="Pass the prefix of the metric you want to have (Only for statsd output format)", default="statsd.ec2instancespricing.hourly")
 
     args = parser.parse_args(args=args)
     return args

--- a/ec2instancespricing/ec2instancespricing.py
+++ b/ec2instancespricing/ec2instancespricing.py
@@ -121,7 +121,14 @@ OUTPUT_FORMATS = [
     "json",
     "table",
     "csv",
-    "line"
+    "line",
+    "statsd"
+]
+
+STATSD_METRIC_TYPES = [
+    "g",
+    "c",
+    "s"
 ]
 
 EC2_REGIONS = [
@@ -758,6 +765,8 @@ def _get_args(args):
     parser.add_argument("--filter-type-pattern", "-fp", help="Filter results to a specific instance type pattern", choices=EC2_INSTANCE_TYPES_PATTERN, default=None)
     parser.add_argument("--filter-os-type", "-fo", help="Filter results to a specific os type", choices=EC2_OS_TYPES, default="linux")
     parser.add_argument("--format", "-f", choices=OUTPUT_FORMATS, help="Output format", default="table")
+    parser.add_argument("--statsd-metric-type", "-smt", help="Define the metric type you want to include in the format- count, guague, etc...", choices=STATSD_METRIC_TYPES, default="g")
+    parser.add_argument("--statsd-prefix", "-sp", help="Pass the prefix of the metric you want to have", default="statsd.ec2instancespricing")
 
     args = parser.parse_args(args=args)
     return args
@@ -865,6 +874,9 @@ if __name__ == "__main__":
             if args.format == "csv":
                 print(', '.join(OUTPUT_FIELD_NAMES))
                 line_format = "%s,%s,%s,%s,%s,%s,%s"
+            elif args.format == "statsd":
+                line_format = "%s.%s.%s:%s|%s"
+                
 
         for r in data["regions"]:
             region_name = r["region"]
@@ -872,10 +884,16 @@ if __name__ == "__main__":
                 for term in it["prices"]:
                     if args.format == "csv" or args.format == "line":
                         x.append(line_format % (region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])))
+                    elif args.format == "statsd":
+                        print("Statsd Metric!")
+                        x.append(line_format % (args.statsd_prefix, region_name, it["type"], none_as_string(it["prices"][term]["hourly"]), args.statsd_metric_type))
                     else:
                         x.add_row([region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])])
 
         if args.format == "csv" or args.format == "line":
             print("\n".join(x))
+        elif args.format == "statsd":
+            for metric in x:
+                print(metric)
         else:
             print(x)

--- a/ec2instancespricing/ec2instancespricing.py
+++ b/ec2instancespricing/ec2instancespricing.py
@@ -833,6 +833,9 @@ def none_as_string(v):
     else:
         return v
 
+def sanitize_metric(m):
+    return m.replace(".","_").replace("/","SLASH").replace(" ","_").replace(":","_")
+
 if __name__ == "__main__":
     args = _get_args(None)
 
@@ -878,7 +881,7 @@ if __name__ == "__main__":
                     if args.format == "csv" or args.format == "line":
                         x.append(line_format % (region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])))
                     elif args.format == "statsd":
-                        x.append(line_format % (args.statsd_prefix, region_name, it["type"], none_as_string(it["prices"][term]["hourly"])))
+                        x.append(line_format % (args.statsd_prefix, sanitize_metric(region_name), sanitize_metric(it["type"]), none_as_string(it["prices"][term]["hourly"])))
                     else:
                         x.add_row([region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])])
 

--- a/ec2instancespricing/ec2instancespricing.py
+++ b/ec2instancespricing/ec2instancespricing.py
@@ -125,12 +125,6 @@ OUTPUT_FORMATS = [
     "statsd"
 ]
 
-STATSD_METRIC_TYPES = [
-    "g",
-    "c",
-    "s"
-]
-
 EC2_REGIONS = [
     "us-east-1",
     "us-east-2",
@@ -765,7 +759,6 @@ def _get_args(args):
     parser.add_argument("--filter-type-pattern", "-fp", help="Filter results to a specific instance type pattern", choices=EC2_INSTANCE_TYPES_PATTERN, default=None)
     parser.add_argument("--filter-os-type", "-fo", help="Filter results to a specific os type", choices=EC2_OS_TYPES, default="linux")
     parser.add_argument("--format", "-f", choices=OUTPUT_FORMATS, help="Output format", default="table")
-    parser.add_argument("--statsd-metric-type", "-smt", help="Define the metric type you want to include in the format- count, guague, etc...", choices=STATSD_METRIC_TYPES, default="g")
     parser.add_argument("--statsd-prefix", "-sp", help="Pass the prefix of the metric you want to have", default="statsd.ec2instancespricing")
 
     args = parser.parse_args(args=args)
@@ -875,7 +868,7 @@ if __name__ == "__main__":
                 print(', '.join(OUTPUT_FIELD_NAMES))
                 line_format = "%s,%s,%s,%s,%s,%s,%s"
             elif args.format == "statsd":
-                line_format = "%s.%s.%s:%s|%s"
+                line_format = "%s.%s.%s:%s|g"
                 
 
         for r in data["regions"]:
@@ -885,8 +878,7 @@ if __name__ == "__main__":
                     if args.format == "csv" or args.format == "line":
                         x.append(line_format % (region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])))
                     elif args.format == "statsd":
-                        print("Statsd Metric!")
-                        x.append(line_format % (args.statsd_prefix, region_name, it["type"], none_as_string(it["prices"][term]["hourly"]), args.statsd_metric_type))
+                        x.append(line_format % (args.statsd_prefix, region_name, it["type"], none_as_string(it["prices"][term]["hourly"])))
                     else:
                         x.add_row([region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])])
 

--- a/ec2instancespricing/ec2instancespricing.py
+++ b/ec2instancespricing/ec2instancespricing.py
@@ -871,7 +871,7 @@ if __name__ == "__main__":
                 print(', '.join(OUTPUT_FIELD_NAMES))
                 line_format = "%s,%s,%s,%s,%s,%s,%s"
             elif args.format == "statsd":
-                line_format = "%s.%s.%s:%s|g"
+                line_format = "%s.%s.%s.%s:%s|g"
                 
 
         for r in data["regions"]:
@@ -881,7 +881,7 @@ if __name__ == "__main__":
                     if args.format == "csv" or args.format == "line":
                         x.append(line_format % (region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])))
                     elif args.format == "statsd":
-                        x.append(line_format % (args.statsd_prefix, sanitize_metric(region_name), sanitize_metric(it["type"]), none_as_string(it["prices"][term]["hourly"])))
+                        x.append(line_format % (args.statsd_prefix, sanitize_metric(region_name), term, sanitize_metric(it["type"]), none_as_string(it["prices"][term]["hourly"])))
                     else:
                         x.add_row([region_name, it["type"], it["os"], none_as_string(it["prices"][term]["hourly"]), it["utilization"], term, none_as_string(it["prices"][term]["upfront_perGB"])])
 


### PR DESCRIPTION
We wanted to put the pricing data in graphite in order of seeing time series data of it. I added the statsd output format to this script so we could just pass the output to netcat command and send it to our statsd server.
We're triggering it using cron to statsd. I'm providing a usage example (that we are already using in our stack):
`./ec2instancespricing.py --type all --filter-region eu-west-1 --filter-os-type linux --format statsd --statsd-prefix 'app.instancepricing'  | nc -w 15 -u <statsd_host> 8125`

Here is an output example (without the netcat command):
`app.instancepricing.eu-west-1.spot.h1_2xlarge:0.1833|g`

We would be glad if you merge this change, we think it might be helpful to other people as well.