### PR TITLE
Fixed up region list to include us-gov-east-1

### DIFF
--- a/ec2instancespricing/ec2instancespricing.py
+++ b/ec2instancespricing/ec2instancespricing.py
@@ -128,6 +128,8 @@ OUTPUT_FORMATS = [
 EC2_REGIONS = [
     "us-east-1",
     "us-east-2",
+    "us-gov-west-1",
+    "us-gov-east-1",
     "us-west-1",
     "us-west-2",
     "eu-west-1",
@@ -142,7 +144,7 @@ EC2_REGIONS = [
     "eu-north-1",
     "eu-west-2",
     "ap-northeast-3",
-    "eu-west-3"
+    "eu-west-3",
 ]
 
 EC2_INSTANCE_TYPES_PATTERN = {
@@ -284,6 +286,7 @@ JSON_NAME_TO_EC2_REGIONS_API = {
     "sa-east-1": "sa-east-1",
 
     "us-gov-west-1": "us-gov-west-1",
+    "us-gov-east-1": "us-gov-east-1",
 
     "ap-south-1": "ap-south-1",
     "ca-central-1" : "ca-central-1",


### PR DESCRIPTION
Script crashes if you run without any arguments, as it didn't know about us-gov-east-1.  

The region list also didn't include us-gov-west-1, but it was included in the instance types pattern for some reason. 

thanks for making this available, it's very helpful.